### PR TITLE
バグフィックス

### DIFF
--- a/MfxFormat.cs
+++ b/MfxFormat.cs
@@ -75,7 +75,7 @@ namespace PLEN.MFX
                     if (tagMotion.Extra.Param.Count != 2)
                         return false;
                     // ParamリストをIDの昇順に並び替え
-                    tagMotion.Extra.Param.Sort((o1, o2) => o1.ID.CompareTo(o2.ID));
+                    tagMotion.Extra.Param.Sort((o1, o2) => (Int32.Parse(o1.ID)).CompareTo(Int32.Parse(o2.ID)));
                     // コマンドを追加
                     strConvertedMfx += byte.Parse(tagMotion.Extra.Function).ToString("x2");
                     strConvertedMfx += byte.Parse(tagMotion.Extra.Param[0].Param).ToString("x2");
@@ -90,14 +90,14 @@ namespace PLEN.MFX
 
                     /*----- システムコマンド「frame」 -----*/
                     // FrameリストをIDの昇順に並び替え
-                    tagMotion.Frame.Sort((o1, o2) => o1.ID.CompareTo(o2.ID));
+                    tagMotion.Frame.Sort((o1, o2) => (Int32.Parse(o1.ID)).CompareTo(Int32.Parse(o2.ID)));
                     strConvertedMfxForDisplay += "[frame : ";
                     foreach (TagFrameModel tagFrame in tagMotion.Frame)
                     {
                         strConvertedMfx += short.Parse(tagFrame.Time).ToString("x4");
                         strConvertedMfxForDisplay += " " + short.Parse(tagFrame.Time).ToString("x4");
                         // JointリストをIDの昇順に並べ替え
-                        tagFrame.Joint.Sort((o1, o2) => o1.ID.CompareTo(o2.ID));
+                        tagFrame.Joint.Sort((o1, o2) => (Int32.Parse(o1.ID)).CompareTo(Int32.Parse(o2.ID)));
                         foreach (TagJointModel tagJoint in tagFrame.Joint)
                         {
                             strConvertedMfx += short.Parse(tagJoint.Joint).ToString("x4");

--- a/SerialCommProcess.cs
+++ b/SerialCommProcess.cs
@@ -303,7 +303,7 @@ namespace BLEMotionInstaller
                     connectedDict[key] = BLEState.Connected;
                     connectedBLEKey = key;
                 }
-                serialCommProcessMessage(this, "Connected");
+                serialCommProcessMessage(this, "Connected [" + connectedBLEKey.ToString() + "]");
                 bleConnectState = BLEState.Connected;
             }
             // 再度接続を試みる
@@ -372,7 +372,7 @@ namespace BLEMotionInstaller
                         Thread.Sleep(1);
 
                     Thread.Sleep(DELAY_INTERVAL);
-                    serialCommProcessMessage(this, "headler written.");
+                    serialCommProcessMessage(this, "header written.");
 
                     Thread.Sleep(50);
                     /*-- frame --*/
@@ -411,7 +411,7 @@ namespace BLEMotionInstaller
 
                         Thread.Sleep(DELAY_INTERVAL);
 
-                        serialCommProcessMessage(this, "frame written. [" + ((index + 1) * 100).ToString() + "/" + (mfxCommandArray.Length - 30).ToString() + "]");
+                        serialCommProcessMessage(this, "frame written. [" + (index + 1).ToString() + "/" + ((mfxCommandArray.Length - 30) / 100).ToString() + "]");
                         Thread.Sleep(50);
                     }
                     serialCommProcessMessage(this, "【" + sendMfxCommand.Name + "】send Complete. ...");


### PR DESCRIPTION
#fix
- 接続時にmacアドレスを表示するように修正
- 進行ログの数値をbyte数ベースからフレーム数ベースへ修正
- 文字列間の比較が辞書式順序でなされることを考慮し、数値に変換してから比較するように修正
- "29_Breake for Forward.mfx"のnameタグに余分な空白が付与されていたせいで、フォーマット指定に失敗していた部分を修正
  (これについてはモーションファイルの方のみ修正なので、別途文字を切り詰める処理を足す。)